### PR TITLE
Bug with the URI parameter 

### DIFF
--- a/pyannote/metrics/base.py
+++ b/pyannote/metrics/base.py
@@ -128,6 +128,7 @@ class BaseMetric(object):
             self.uris_[uri] = 1
         else:
             self.uris_[uri] += 1
+            print('SALUUUUUUUUUT')
             uri = uri , ' #{0:d}'.format(self.uris_[uri])
 
         self.results_.append((uri, components))

--- a/pyannote/metrics/base.py
+++ b/pyannote/metrics/base.py
@@ -128,7 +128,7 @@ class BaseMetric(object):
             self.uris_[uri] = 1
         else:
             self.uris_[uri] += 1
-            uri = uri + ' #{0:d}'.format(self.uris_[uri])
+            uri = uri , ' #{0:d}'.format(self.uris_[uri])
 
         self.results_.append((uri, components))
 

--- a/pyannote/metrics/base.py
+++ b/pyannote/metrics/base.py
@@ -128,8 +128,7 @@ class BaseMetric(object):
             self.uris_[uri] = 1
         else:
             self.uris_[uri] += 1
-            print('SALUUUUUUUUUT')
-            uri = uri , ' #{0:d}'.format(self.uris_[uri])
+            uri = uri, ' #{0:d}'.format(self.uris_[uri])
 
         self.results_.append((uri, components))
 


### PR DESCRIPTION
From the provided [Jupyter Notebook](https://nbviewer.jupyter.org/github/pyannote/pyannote-metrics/blob/master/notebooks/index.ipynb) to get started with Pyannote-metrics, it was throwing an error when running the whole notebook as is for this line:

```
diarizationErrorRate(reference, hypothesis, detailed=True, uem=Segment(0, 40))
```

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-58-445b485ca05e> in <module>
----> 1 diarizationErrorRate(reference, hypothesis, detailed=True, uem=Segment(0, 40))

/srv/conda/envs/notebook/lib/python3.7/site-packages/pyannote/metrics/base.py in __call__(self, reference, hypothesis, detailed, **kwargs)
    129         else:
    130             self.uris_[uri] += 1
--> 131             uri = uri + ' #{0:d}'.format(self.uris_[uri])
    132 
    133         self.results_.append((uri, components))

TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

The `uri` parameter is used to remember which document it describes, it's optional. As it was empty in the Notebook, it throws an error to concatenate `NoneType + str`. 

This PR changes the `+` operand for `,` so that the `uri` parameter can be `None`. 

I tested this PR with `pip install git+https://git@github.com/Mymoza/pyannote-metrics.git@mpgill-uri-bug` and it works well now:

```
{'confusion': 7.0,
 'correct': 22.0,
 'diarization error rate': 0.5161290322580645,
 'false alarm': 7.0,
 'missed detection': 2.0,
 'total': 31.0}
```