### PR TITLE
fix: rewrite mapping and matching routines

### DIFF
--- a/pyannote/metrics/__init__.py
+++ b/pyannote/metrics/__init__.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2016 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,6 @@
 
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
-
-from __future__ import unicode_literals
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/pyannote/metrics/base.py
+++ b/pyannote/metrics/base.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2017 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,10 +25,6 @@
 
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
-
-
-from __future__ import unicode_literals
-from __future__ import print_function
 
 
 import scipy.stats

--- a/pyannote/metrics/detection.py
+++ b/pyannote/metrics/detection.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2017 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,6 @@
 
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
-
-from __future__ import unicode_literals
 
 from pyannote.core import Annotation, Timeline
 from .base import BaseMetric

--- a/pyannote/metrics/diarization.py
+++ b/pyannote/metrics/diarization.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2017 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,6 @@
 
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
-
-from __future__ import unicode_literals
 
 """Metrics for diarization"""
 

--- a/pyannote/metrics/diarization.py
+++ b/pyannote/metrics/diarization.py
@@ -141,10 +141,10 @@ class DiarizationErrorRate(IdentificationErrorRate):
         # might have an impact on the search for the optimal mapping.
 
         # make sure reference only contains string labels ('A', 'B', ...)
-        reference = reference.anonymize_labels(generator='string')
+        reference = reference.rename_labels(generator='string')
 
         # make sure hypothesis only contains integer labels (1, 2, ...)
-        hypothesis = hypothesis.anonymize_labels(generator='int')
+        hypothesis = hypothesis.rename_labels(generator='int')
 
         # optimal (int --> str) mapping
         mapping = self.optimal_mapping(reference, hypothesis)
@@ -152,7 +152,7 @@ class DiarizationErrorRate(IdentificationErrorRate):
         # compute identification error rate based on mapped hypothesis
         # NOTE that collar is set to 0.0 because 'uemify' has already
         # been applied (same reason for setting skip_overlap to False)
-        mapped = hypothesis.translate(mapping)
+        mapped = hypothesis.rename_labels(mapping=mapping)
         return super(DiarizationErrorRate, self)\
             .compute_components(reference, mapped, uem=uem,
                                 collar=0.0, skip_overlap=False,
@@ -251,10 +251,10 @@ class GreedyDiarizationErrorRate(IdentificationErrorRate):
         # might have an impact on the search for the greedy mapping.
 
         # make sure reference only contains string labels ('A', 'B', ...)
-        reference = reference.anonymize_labels(generator='string')
+        reference = reference.rename_labels(generator='string')
 
         # make sure hypothesis only contains integer labels (1, 2, ...)
-        hypothesis = hypothesis.anonymize_labels(generator='int')
+        hypothesis = hypothesis.rename_labels(generator='int')
 
         # greedy (int --> str) mapping
         mapping = self.greedy_mapping(reference, hypothesis)
@@ -262,7 +262,7 @@ class GreedyDiarizationErrorRate(IdentificationErrorRate):
         # compute identification error rate based on mapped hypothesis
         # NOTE that collar is set to 0.0 because 'uemify' has already
         # been applied (same reason for setting skip_overlap to False)
-        mapped = hypothesis.translate(mapping)
+        mapped = hypothesis.rename_labels(mapping=mapping)
         return super(GreedyDiarizationErrorRate, self)\
             .compute_components(reference, mapped, uem=uem,
                                 collar=0.0, skip_overlap=False,
@@ -364,10 +364,10 @@ class JaccardErrorRate(DiarizationErrorRate):
         # might have an impact on the search for the optimal mapping.
 
         # make sure reference only contains string labels ('A', 'B', ...)
-        reference = reference.anonymize_labels(generator='string')
+        reference = reference.rename_labels(generator='string')
 
         # make sure hypothesis only contains integer labels (1, 2, ...)
-        hypothesis = hypothesis.anonymize_labels(generator='int')
+        hypothesis = hypothesis.rename_labels(generator='int')
 
         # optimal (str --> int) mapping
         mapping = self.optimal_mapping(hypothesis, reference)

--- a/pyannote/metrics/errors/__init__.py
+++ b/pyannote/metrics/errors/__init__.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2016 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,7 +25,5 @@
 
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
-
-from __future__ import unicode_literals
 
 """Error analysis"""

--- a/pyannote/metrics/errors/identification.py
+++ b/pyannote/metrics/errors/identification.py
@@ -32,7 +32,6 @@ from scipy.optimize import linear_sum_assignment
 
 from ..matcher import LabelMatcher
 from pyannote.core import Annotation
-from xarray import DataArray
 
 from ..matcher import MATCH_CORRECT, MATCH_CONFUSION, \
     MATCH_MISSED_DETECTION, MATCH_FALSE_ALARM
@@ -260,6 +259,16 @@ class IdentificationErrorAnalysis(UEMSupportMixin, object):
         ] + hLabels
 
         # initialize empty matrix
+
+        try:
+            from xarray import DataArray
+        except ImportError as e:
+            msg = (
+                "Please install xarray dependency to use class "
+                "'IdentificationErrorAnalysis'."
+            )
+            raise ImportError(msg)
+
         matrix = DataArray(
             np.zeros((len(rLabels), len(hLabels))),
             coords=[('reference', rLabels), ('hypothesis', hLabels)])

--- a/pyannote/metrics/errors/identification.py
+++ b/pyannote/metrics/errors/identification.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2017 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,8 +26,6 @@
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
 # Benjamin MAURICE - maurice@limsi.fr
-
-from __future__ import unicode_literals
 
 import numpy as np
 from munkres import Munkres

--- a/pyannote/metrics/errors/identification.py
+++ b/pyannote/metrics/errors/identification.py
@@ -28,7 +28,7 @@
 # Benjamin MAURICE - maurice@limsi.fr
 
 import numpy as np
-from munkres import Munkres
+from scipy.optimize import linear_sum_assignment
 
 from ..matcher import LabelMatcher
 from pyannote.core import Annotation
@@ -65,7 +65,6 @@ class IdentificationErrorAnalysis(UEMSupportMixin, object):
 
         super(IdentificationErrorAnalysis, self).__init__()
         self.matcher = LabelMatcher()
-        self.munkres = Munkres()
         self.collar = collar
         self.skip_overlap=skip_overlap
 
@@ -171,9 +170,7 @@ class IdentificationErrorAnalysis(UEMSupportMixin, object):
                 for i2, e2 in enumerate(new_errors):
                     match[i1, i2] = self._match_errors(e1, e2)
 
-            mapping = self.munkres.compute(2 - match)
-
-            for i1, i2 in mapping:
+            for i1, i2 in zip(*linear_sum_assignment(-match)):
 
                 if i1 >= n1:
                     track = behaviors.new_track(segment,

--- a/pyannote/metrics/identification.py
+++ b/pyannote/metrics/identification.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2017 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,6 @@
 
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
-
-from __future__ import unicode_literals
 
 from .base import BaseMetric
 from .base import Precision, PRECISION_RETRIEVED, PRECISION_RELEVANT_RETRIEVED

--- a/pyannote/metrics/matcher.py
+++ b/pyannote/metrics/matcher.py
@@ -27,8 +27,7 @@
 # Hervé BREDIN - http://herve.niderb.fr
 
 import numpy as np
-from munkres import Munkres
-import networkx as nx
+from scipy.optimize import linear_sum_assignment
 
 MATCH_CORRECT = 'correct'
 MATCH_CONFUSION = 'confusion'
@@ -45,10 +44,6 @@ class LabelMatcher(object):
     .match() -- ie return True if two IDs match and False
     otherwise.
     """
-
-    def __init__(self):
-        super(LabelMatcher, self).__init__()
-        self._munkres = Munkres()
 
     def match(self, rlabel, hlabel):
         """
@@ -107,7 +102,7 @@ class LabelMatcher(object):
         if N == 0:
             return (counts, details)
 
-        # this is to make sure rlables and hlabels are lists
+        # this is to make sure rlabels and hlabels are lists
         # as we will access them later by index
         rlabels = list(rlabels)
         hlabels = list(hlabels)
@@ -120,11 +115,8 @@ class LabelMatcher(object):
                 match[r, h] = self.match(rlabel, hlabel)
 
         # find one-to-one mapping that maximize total number of matches
-        # using the Hungarian algorithm
-        mapping = self._munkres.compute(1 - match)
-
-        # loop on matches
-        for r, h in mapping:
+        # using the Hungarian algorithm and computes error accordingly
+        for r, h in zip(*linear_sum_assignment(~match)):
 
             # hypothesis label is matched with unexisting reference label
             # ==> this is a false alarm
@@ -158,64 +150,15 @@ class LabelMatcher(object):
 
 class HungarianMapper(object):
 
-    def __init__(self):
-        super(HungarianMapper, self).__init__()
-        self._munkres = Munkres()
-
-    def _helper(self, A, B):
-
-        # transpose matrix in case A has more labels than B
-        Na = len(A.labels())
-        Nb = len(B.labels())
-        if Na > Nb:
-            return {a: b for (b, a) in self._helper(B, A).items()}
-
-        matrix = A * B
-        mapping = self._munkres.compute(matrix.max() - matrix)
-
-        return dict(
-            (matrix.coords['i'][i].item(), matrix.coords['j'][j].item())
-            for i, j in mapping if matrix[i, j] > 0)
-
     def __call__(self, A, B):
+        mapping = {}
 
-        # build bi-partite cooccurrence graph
-        # ------------------------------------
+        cooccurrence = A * B
+        a_labels, b_labels = A.labels(), B.labels()
 
-        # labels from A are linked with labels from B
-        # if and only if the co-occur
-        cooccurrence_graph = nx.Graph()
-
-        # for a_label in A.labels():
-        #     a = ('A', a_label)
-        #     cooccurrence_graph.add_node(a)
-        #
-        # for b_label in B.labels():
-        #     b = ('B', b_label)
-        #     cooccurrence_graph.add_node(b)
-
-        for a_track, b_track in A.co_iter(B):
-            a = ('A', A[a_track])
-            b = ('B', B[b_track])
-            cooccurrence_graph.add_edge(a, b)
-
-        # divide & conquer
-        # ------------------
-
-        # split a (potentially large) association problem into smaller ones
-
-        mapping = dict()
-
-        for component in nx.connected_components(cooccurrence_graph):
-
-            # extract smaller problems
-            a_labels = [label for (src, label) in component if src == 'A']
-            b_labels = [label for (src, label) in component if src == 'B']
-            sub_A = A.subset(a_labels)
-            sub_B = B.subset(b_labels)
-
-            local_mapping = self._helper(sub_A, sub_B)
-            mapping.update(local_mapping)
+        for a, b in zip(*linear_sum_assignment(-cooccurrence)):
+            if cooccurrence[a, b] > 0:
+                mapping[a_labels[a]] = b_labels[b]
 
         return mapping
 
@@ -223,29 +166,21 @@ class HungarianMapper(object):
 class GreedyMapper(object):
 
     def __call__(self, A, B):
-
-        matrix = A * B
-        Na, Nb = matrix.shape
-        N = min(Na, Nb)
-
         mapping = {}
 
-        for i in range(N):
+        cooccurrence = A * B
+        Na, Nb = cooccurrence.shape
+        a_labels, b_labels = A.labels(), B.labels()
 
-            ab = np.argmax(matrix.data)
-            a = ab // (Nb-i)
-            b = ab % (Nb-i)
+        for i in range(min(Na, Nb)):
+            a, b = np.unravel_index(np.argmax(cooccurrence), (Na, Nb))
 
-            cost = matrix[a, b].item()
+            if cooccurrence[a, b] > 0:
+                mapping[a_labels[a]] = b_labels[b]
+                cooccurrence[a, :] = 0.
+                cooccurrence[:, b] = 0.
+                continue
 
-            if cost == 0:
-                break
-
-            alabel = matrix.coords['i'][a].item()
-            blabel = matrix.coords['j'][b].item()
-
-            mapping[alabel] = blabel
-
-            matrix = matrix.drop([alabel], dim='i').drop([blabel], dim='j')
+            break
 
         return mapping

--- a/pyannote/metrics/matcher.py
+++ b/pyannote/metrics/matcher.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2017 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,6 @@
 
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
-
-from __future__ import unicode_literals
 
 import numpy as np
 from munkres import Munkres

--- a/pyannote/metrics/segmentation.py
+++ b/pyannote/metrics/segmentation.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2017 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +28,6 @@
 # Camille Guinaudeau - https://sites.google.com/site/cguinaudeau/
 # Mamadou Doumbia
 # Diego Fustes diego.fustes at toptal.com
-
-from __future__ import division
-from __future__ import unicode_literals
 
 import numpy as np
 from pyannote.core import Segment, Timeline, Annotation

--- a/pyannote/metrics/segmentation.py
+++ b/pyannote/metrics/segmentation.py
@@ -83,7 +83,7 @@ class SegmentationCoverage(BaseMetric):
             segment = Segment(start, end)
             partition[segment] = '_'
 
-        return partition.crop(coverage, mode='intersection').anonymize_tracks()
+        return partition.crop(coverage, mode='intersection').relabel_tracks()
 
     def _preprocess(self, reference, hypothesis):
 

--- a/pyannote/metrics/spotting.py
+++ b/pyannote/metrics/spotting.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2017 CNRS
+# Copyright (c) 2017-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,6 @@
 
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
-
-from __future__ import unicode_literals
 
 import sys
 import numpy as np

--- a/pyannote/metrics/utils.py
+++ b/pyannote/metrics/utils.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2012-2017 CNRS
+# Copyright (c) 2012-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,6 @@
 
 # AUTHORS
 # Hervé BREDIN - http://herve.niderb.fr
-
-from __future__ import unicode_literals
 
 import warnings
 from pyannote.core import Timeline, Segment

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2014-2018 CNRS
+# Copyright (c) 2014-2019 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -43,13 +43,11 @@ setup(
         'scripts/pyannote-metrics.py',
     ],
     install_requires=[
-        'pyannote.core >= 2.1',
+        'pyannote.core >= 3.0',
         'pyannote.database >= 2.0',
         'pandas >= 0.19',
-        'scipy >= 0.10.0',
+        'scipy >= 1.1.0',
         'scikit-learn >= 0.17.1',
-        'networkx >= 1.11',
-        'munkres >= 1.0.8',
         'docopt >= 0.6.2',
         'tabulate >= 0.7.7',
         'matplotlib >= 2.0.0',


### PR DESCRIPTION
pyannote.core 3.x changes the return type of Annotation.__mul__ (from xarray.DataArray to np.ndarray) because it was found that recent changes in xarray led to inconsistency in diarization metrics. "xarray" is still used in IdentificationErrorAnalysis.matrix but is meant to be removed completely in the future.

Also, "scipy" now provides an implementation of the Hungarian algorithm (supposedly faster than that of "munkres") so we switch to a recent version of "scipy".

Therefore, the code for "HungarianMapper" and "GreedyMapper" has been rewritten to rely on those two things. This also has the side effect of removing both "networkx" and "munkres" dependency.