### PR TITLE
fix: handle empty annotations in segmentation metrics

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 #########
 
+Next
+~~~~
+
+- fix(segmentation): fix segmentation metrics for empty references
+
 Version 4.1.0 (2026-05-06)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/pyannote/metrics/segmentation.py
+++ b/src/pyannote/metrics/segmentation.py
@@ -126,7 +126,9 @@ class SegmentationCoverage(BaseMetric):
         # cooccurrence matrix
         K = reference * hypothesis
         detail[PTY_CVG_TOTAL] = np.sum(K).item()
-        detail[PTY_CVG_INTER] = np.sum(np.max(K, axis=1)).item()
+        # np.max has no identity on an empty matrix, which happens when either
+        # annotation is empty. Nothing is covered in that case.
+        detail[PTY_CVG_INTER] = np.sum(np.max(K, axis=1)).item() if K.size else 0.
 
         return detail
 
@@ -144,6 +146,8 @@ class SegmentationCoverage(BaseMetric):
         return self._process(reference, hypothesis)
 
     def compute_metric(self, detail: Details) -> float:
+        if detail[PTY_CVG_TOTAL] == 0.:
+            return 1.
         return detail[PTY_CVG_INTER] / detail[PTY_CVG_TOTAL]
 
 
@@ -206,11 +210,11 @@ class SegmentationPurityCoverageFMeasure(SegmentationCoverage):
         # cooccurrence matrix coverage
         K = reference * hypothesis
         detail[CVG_TOTAL] = np.sum(K).item()
-        detail[CVG_INTER] = np.sum(np.max(K, axis=1)).item()
+        detail[CVG_INTER] = np.sum(np.max(K, axis=1)).item() if K.size else 0.
 
         # cooccurrence matrix purity
         detail[PTY_TOTAL] = detail[CVG_TOTAL]
-        detail[PTY_INTER] = np.sum(np.max(K, axis=0)).item()
+        detail[PTY_INTER] = np.sum(np.max(K, axis=0)).item() if K.size else 0.
 
         return detail
 

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,0 +1,65 @@
+import pytest
+from pyannote.core import Annotation, Segment
+
+from pyannote.metrics.segmentation import (
+    SegmentationCoverage,
+    SegmentationPurity,
+    SegmentationPurityCoverageFMeasure,
+)
+
+METRICS = [
+    SegmentationCoverage,
+    SegmentationPurity,
+    SegmentationPurityCoverageFMeasure,
+]
+
+
+@pytest.fixture
+def reference():
+    reference = Annotation()
+    reference[Segment(0, 20)] = "A"
+    reference[Segment(20, 40)] = "B"
+    return reference
+
+
+@pytest.fixture
+def hypothesis():
+    hypothesis = Annotation()
+    hypothesis[Segment(0, 5)] = "a"
+    hypothesis[Segment(5, 25)] = "b"
+    hypothesis[Segment(25, 40)] = "c"
+    return hypothesis
+
+
+@pytest.mark.parametrize("metric_class", METRICS)
+def test_empty_annotations(metric_class):
+    """Empty annotations produce an empty cooccurrence matrix, which used to
+    raise ValueError from np.max (and ZeroDivisionError once reached)."""
+    metric = metric_class()
+    assert metric(Annotation(), Annotation()) == 1.0
+
+
+@pytest.mark.parametrize("metric_class", METRICS)
+def test_empty_hypothesis(metric_class, reference):
+    metric = metric_class()
+    assert metric(reference, Annotation()) == 1.0
+
+
+@pytest.mark.parametrize("metric_class", METRICS)
+def test_empty_reference(metric_class, hypothesis):
+    metric = metric_class()
+    assert metric(Annotation(), hypothesis) == 1.0
+
+
+def test_perfect_segmentation(reference):
+    for metric_class in METRICS:
+        assert metric_class()(reference, reference) == 1.0
+
+
+def test_imperfect_segmentation(reference, hypothesis):
+    """Guarding the empty case must not change the values for real input."""
+    assert SegmentationPurity()(reference, hypothesis) == pytest.approx(0.875)
+    assert SegmentationCoverage()(reference, hypothesis) == pytest.approx(0.75)
+    assert SegmentationPurityCoverageFMeasure()(
+        reference, hypothesis
+    ) == pytest.approx(0.8076923076923077)


### PR DESCRIPTION
Fixes #36.

### Problem

The reproducer from #36 still raises on `develop`:

```python
from pyannote.core import Annotation
from pyannote.metrics.segmentation import SegmentationPurity
SegmentationPurity()(Annotation(), Annotation())
# ValueError: zero-size array to reduction operation maximum which has no identity
```

All three of `SegmentationCoverage`, `SegmentationPurity` and `SegmentationPurityCoverageFMeasure` fail.

### Cause

`_process` builds the cooccurrence matrix `K = reference * hypothesis` and calls `np.max(K, axis=...)`. When either annotation is empty, `K` is zero-size and `np.max` has no identity. `SegmentationCoverage.compute_metric` then also divides by a zero total.

Worth noting: `SegmentationPurityCoverageFMeasure.compute_metrics` **already** returns `1.` when the total is zero — but that guard was unreachable, because `_process` raised before it ran.

### Change

- Guard the `np.max` calls so an empty matrix contributes `0.` instead of raising (both `_process` implementations).
- Give `SegmentationCoverage.compute_metric` the same zero-total guard its sibling already uses.

All three metrics now return `1.` for empty input, consistent with the existing `SegmentationPurityCoverageFMeasure` behaviour.

### Testing

`tests/test_segmentation.py` is new (there was no test module for this file). It covers empty reference, empty hypothesis, both-empty, perfect segmentation, and — importantly — asserts the exact values for a real imperfect segmentation (purity `0.875`, coverage `0.75`, F-measure `0.8077`) so the guard cannot silently change existing results.

Before the change 9 of the new tests fail with the errors from #36; after it all 11 pass, and the existing suite goes from 19 to 30 passing with no regressions.