### PR TITLE
fix: guard JaccardErrorRate against an empty reference

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 #########
 
+Next
+~~~~
+
+- fix: fix metrics for empty references (@Atishyy27)
+
 Version 4.1.0 (2026-05-06)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/pyannote/metrics/diarization.py
+++ b/src/pyannote/metrics/diarization.py
@@ -456,7 +456,9 @@ class JaccardErrorRate(DiarizationErrorRate):
         return detail
 
     def compute_metric(self, detail: Details) -> float:
-        return detail[JER_SPEAKER_ERROR] / detail[JER_SPEAKER_COUNT]
+        if detail[JER_SPEAKER_COUNT] > 0.0:
+            return detail[JER_SPEAKER_ERROR] / detail[JER_SPEAKER_COUNT]
+        return 1.0
 
 
 PURITY_NAME = "purity"

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -113,3 +113,12 @@ def test_bug_16():
     metric = DiarizationErrorRate(collar=0)
     total = metric(reference, hypothesis, detailed=True)["total"]
     npt.assert_almost_equal(total, 10, decimal=3)
+
+
+def test_jaccard_error_rate_empty_reference():
+    from pyannote.metrics.diarization import JaccardErrorRate
+
+    hypothesis = Annotation()
+    hypothesis[Segment(0, 10)] = "spk"
+    # empty reference -> zero speaker count -> must not ZeroDivisionError
+    assert JaccardErrorRate()(Annotation(), hypothesis) == 1.0


### PR DESCRIPTION
Fixes the ZeroDivisionError reported above.

### Problem

`JaccardErrorRate.compute_metric` divides by `JER_SPEAKER_COUNT` (incremented per reference speaker) with no zero guard, so an empty reference raises `ZeroDivisionError`. It's the only metric in the package that crashes on empty input.

### Change

Return `1.0` when the speaker count is zero — mirroring `DiarizationPurity.compute_metric` and consistent with `DiarizationErrorRate` (both return `1.0` on this input).

### Testing

Added `test_jaccard_error_rate_empty_reference`. It fails on the original code (`ZeroDivisionError`) and passes after the guard; the existing diarization tests are unaffected (9/9 pass).