### PR TITLE
fix: clamp SegmentationPrecision boundary counts for empty timelines

### DIFF
--- a/src/pyannote/metrics/segmentation.py
+++ b/src/pyannote/metrics/segmentation.py
@@ -303,8 +303,8 @@ class SegmentationPrecision(UEMSupportMixin, BaseMetric):
         n_matches = 0.  # make sure it is a float (for later ratio)
 
         # number of boundaries in reference and hypothesis
-        N = len(reference) - 1
-        M = len(hypothesis) - 1
+        N = max(0, len(reference) - 1)
+        M = max(0, len(hypothesis) - 1)
 
         # number of boundaries in hypothesis
         detail[PR_BOUNDARIES] = M

--- a/tests/test_segmentation_precision.py
+++ b/tests/test_segmentation_precision.py
@@ -1,0 +1,16 @@
+from pyannote.core import Segment, Timeline
+
+from pyannote.metrics.segmentation import SegmentationPrecision
+
+
+def test_segmentation_precision_empty_hypothesis():
+    ref = Timeline([Segment(0, 1), Segment(1, 2), Segment(2, 3)])
+    # empty hypothesis with >=2 reference segments used to crash np.zeros((N, -1))
+    assert SegmentationPrecision()(ref, Timeline()) == 1.0
+
+    # accumulating an empty hypothesis used to push a boundary count of -1,
+    # giving a corpus precision > 1
+    m = SegmentationPrecision()
+    m(ref, ref)
+    m(Timeline([Segment(0, 3)]), Timeline())
+    assert abs(m) <= 1.0


### PR DESCRIPTION
Fixes the issue above.

### Problem

`SegmentationPrecision._process` computes `N = len(reference) - 1`, `M = len(hypothesis) - 1` and only guards `== 0`. An empty timeline (`len == 0`) makes these `-1`, which slips past the guard — accumulating a negative boundary count (corpus precision `> 1`) for a single-segment case, and crashing in `np.zeros((N, -1))` for a `>=2`-segment case. `SegmentationRecall` inherits this.

### Change

Clamp both to `max(0, len - 1)`. The existing `== 0` guard then short-circuits empty inputs correctly, and `compute_metric` already returns cleanly when the denominator is 0.

### Testing

`tests/test_segmentation_precision.py`: empty hypothesis with a multi-segment reference (was `ValueError`) and an accumulated empty hypothesis (was precision `> 1`). Fails on the original code, passes after the clamp.