### PR TITLE
fix: match segmentation boundaries optimally instead of greedily

### DIFF
--- a/src/pyannote/metrics/segmentation.py
+++ b/src/pyannote/metrics/segmentation.py
@@ -33,6 +33,7 @@ from typing import Tuple, Union, Optional
 import numpy as np
 from pyannote.core import Segment, Timeline, Annotation
 from pyannote.core.utils.generators import pairwise
+from scipy.optimize import linear_sum_assignment
 
 from .base import BaseMetric, f_measure
 from .types import MetricComponents, Details
@@ -328,30 +329,21 @@ class SegmentationPrecision(UEMSupportMixin, BaseMetric):
             for h, hypBoundary in enumerate(hyp_boundaries):
                 delta[r, h] = abs(refBoundary - hypBoundary)
 
-        # make sure boundaries too far apart from each other cannot be matched
-        # (this is what np.inf is used for)
-        delta[np.where(delta > self.tolerance)] = np.inf
+        # pair boundaries so that the number of matches is maximum, using the
+        # same optimal assignment as `pyannote.metrics.matcher`. matching them
+        # greedily (closest pair first) is not optimal: a close pair may use up
+        # the only in-tolerance partner of another boundary, which then goes
+        # unmatched. boundaries too far apart are given a prohibitive cost, so
+        # they are only ever paired when nothing in tolerance is left -- such
+        # pairs are discarded below. min(N, M) * tolerance is the largest total
+        # cost an all-in-tolerance assignment can reach, so a prohibitive cost
+        # above it can never be preferred over an in-tolerance match.
+        prohibitive = min(N, M) * self.tolerance + 1.
+        cost = np.where(delta > self.tolerance, prohibitive, delta)
 
-        # h always contains the minimum value in delta matrix
-        # h == np.inf means that no boundary can be matched
-        h = np.amin(delta)
-
-        # while there are still boundaries to match
-        while h < np.inf:
-            # increment match count
-            n_matches += 1
-
-            # find boundaries to match
-            k = np.argmin(delta)
-            i = k // M
-            j = k % M
-
-            # make sure they cannot be matched again
-            delta[i, :] = np.inf
-            delta[:, j] = np.inf
-
-            # update minimum value in delta
-            h = np.amin(delta)
+        for r, h in zip(*linear_sum_assignment(cost)):
+            if delta[r, h] <= self.tolerance:
+                n_matches += 1
 
         detail[PR_MATCHES] = n_matches
         return detail

--- a/tests/test_segmentation_precision.py
+++ b/tests/test_segmentation_precision.py
@@ -1,6 +1,18 @@
 from pyannote.core import Segment, Timeline
 
-from pyannote.metrics.segmentation import SegmentationPrecision
+from pyannote.metrics.segmentation import SegmentationPrecision, SegmentationRecall
+
+
+def test_segmentation_precision_recall_dense_boundaries():
+    # reference boundaries are {10, 11.5}, hypothesis boundaries are {11, 12.5}
+    ref = Timeline([Segment(0, 10), Segment(10, 11.5), Segment(11.5, 20)])
+    hyp = Timeline([Segment(0, 11), Segment(11, 12.5), Segment(12.5, 20)])
+
+    # 11 <-> 10 and 12.5 <-> 11.5 are both within tolerance, so every boundary
+    # can be matched. matching greedily picked the closest pair (11 <-> 11.5)
+    # first, which left 12.5 without a partner and halved both scores.
+    assert SegmentationPrecision(tolerance=1.1)(ref, hyp) == 1.0
+    assert SegmentationRecall(tolerance=1.1)(ref, hyp) == 1.0
 
 
 def test_segmentation_precision_empty_hypothesis():


### PR DESCRIPTION
Closes #95.

`SegmentationPrecision` paired reference and hypothesis boundaries by repeatedly taking the globally closest pair and removing its row and column. That is a greedy heuristic rather than a maximum matching: a close pair can consume the only in-tolerance partner of another boundary, which is then counted as unmatched, so precision and recall come out lower than the definition gives. `SegmentationRecall` inherits the same code path.

With reference boundaries `{10, 11.5}` and hypothesis boundaries `{11, 12.5}` at `tolerance=1.1`, both boundaries can be matched (`11` to `10` and `12.5` to `11.5`, each at distance 1.0), so both scores should be `1.0`. The greedy pass matched `11` to `11.5` first because 0.5 was the smallest distance, leaving `12.5` unmatched and returning `0.5`.

This replaces the greedy loop with the optimal assignment already used in `matcher.py` and `errors/identification.py`, so no new dependency is introduced. Pairs further apart than the tolerance are given a cost above the largest total an all-in-tolerance assignment can reach, so they are only ever selected when nothing in tolerance is left, and they are discarded when counting.

## Testing

`test_segmentation_precision_recall_dense_boundaries` covers the case above and fails on `develop`:

```
tests/test_segmentation_precision.py::test_segmentation_precision_recall_dense_boundaries FAILED
```

With the change the full suite passes (33 tests). The docstring examples for both metrics are unchanged (`0.6666666666666666` and `1.0` for precision, `1.0` and `0.0` for recall) since they use the default `tolerance=0`, where greedy matching is already optimal.