### PR TITLE
feat: add metrics together to evaluate files in parallel

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -96,6 +96,34 @@ The internal accumulator can be reset using the :func:`~pyannote.metrics.base.Ba
    In [12]: metric.reset()
 
 
+Parallel processing
+-------------------
+
+Metrics can be added together, which makes it possible to evaluate files in parallel.
+Evaluate each file with its own metric (for instance in a `joblib` worker), then add the metrics.
+The sum holds the results and accumulated components of every file, so ``abs`` and :func:`~pyannote.metrics.base.BaseMetric.report` behave as if a single metric had evaluated all of them.
+
+.. code-block:: python
+
+    from joblib import Parallel, delayed
+    from pyannote.metrics.diarization import DiarizationErrorRate
+
+    def evaluate(reference, hypothesis, uem):
+        metric = DiarizationErrorRate()
+        metric(reference, hypothesis, uem=uem)
+        return metric
+
+    metrics = Parallel(n_jobs=8)(
+        delayed(evaluate)(references[uri], hypotheses[uri], uems[uri])
+        for uri in uris
+    )
+    metric = sum(metrics)
+    report = metric.report(display=True)
+
+Only metrics of the same class, initialized with the same options (e.g. ``skip_overlap``), can be added.
+:func:`~pyannote.metrics.base.BaseMetric.clone` returns a new, empty metric with the same options as an existing one.
+
+
 Evaluation map
 --------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 Next
 ~~~~
 
+- feat: add support for adding metrics together, to evaluate files in parallel (@nryant, @Atishyy27)
 - fix: fix metrics for empty references (@Atishyy27)
 
 Version 4.1.0 (2026-05-06)

--- a/src/pyannote/metrics/base.py
+++ b/src/pyannote/metrics/base.py
@@ -27,6 +27,7 @@
 # Hervé BREDIN - http://herve.niderb.fr
 from typing import List, Union, Optional, Set, Tuple
 
+import copy
 import warnings
 import numpy as np
 import pandas as pd
@@ -80,9 +81,6 @@ class BaseMetric:
     def name(self):
         """Metric name."""
         return self.metric_name()
-
-    # TODO: use joblib/locky to allow parallel processing?
-    # TODO: signature could be something like __call__(self, reference_iterator, hypothesis_iterator, ...)
 
     def __call__(self, reference: Union[Timeline, Annotation],
                  hypothesis: Union[Timeline, Annotation],
@@ -246,6 +244,71 @@ class BaseMetric:
         """Iterator over the accumulated (uri, value)"""
         for uri, component in self.results_:
             yield uri, component
+
+    def clone(self) -> "BaseMetric":
+        """Construct a new empty metric with the same parameters as `self`.
+
+        Clone does a deep copy of the metric without actually copying any
+        results or accumulators. It returns a new metric (with the same
+        parameters) that has not yet been used to evaluate any data.
+        """
+        metric = self.__class__.__new__(self.__class__)
+        for name, value in vars(self).items():
+            if name not in ("accumulated_", "results_"):
+                setattr(metric, name, copy.deepcopy(value))
+        metric.reset()
+        return metric
+
+    def _options(self) -> dict:
+        # options (e.g. `collar`) are plain attributes, while anything set up
+        # at init or accumulated during evaluation ends with an underscore
+        return {
+            name: value for name, value in vars(self).items() if not name.endswith("_")
+        }
+
+    def __add__(self, other) -> "BaseMetric":
+        """Combine metrics that evaluated different files
+
+        This allows evaluating files in parallel: each worker evaluates its
+        own files with its own metric, and the metrics are then added.
+        ``abs(a + b)`` is the value a single metric would have after
+        evaluating the files of both ``a`` and ``b``.
+
+        Raises
+        ------
+        TypeError
+            If metrics are not instances of the same class.
+        ValueError
+            If metrics were not initialized with the same options.
+        """
+        if not isinstance(other, BaseMetric):
+            return NotImplemented
+
+        if type(other) is not type(self):
+            raise TypeError(
+                f"Cannot add {type(self).__name__} and {type(other).__name__}."
+            )
+
+        options, other_options = self._options(), other._options()
+        for name in sorted(set(options) | set(other_options)):
+            if not np.array_equal(options.get(name), other_options.get(name)):
+                raise ValueError(
+                    f"Cannot add metrics with different options: "
+                    f"{name}={options.get(name)!r} and {name}={other_options.get(name)!r}."
+                )
+
+        metric = self.clone()
+        metric.results_ = self.results_ + other.results_
+        for name in self.components_:
+            metric.accumulated_[name] = self.accumulated_[name] + other.accumulated_[name]
+        return metric
+
+    def __radd__(self, other) -> "BaseMetric":
+        # the built-in sum() starts from 0 (its `start` argument), so 0 acts as
+        # an empty metric: sum([a, b]) is (0 + a) + b, which is a + b
+        if isinstance(other, (int, float)) and other == 0:
+            return self.clone() + self
+        return NotImplemented
 
     def compute_components(self,
                            reference: Union[Timeline, Annotation],

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,132 @@
+import pickle
+
+import pytest
+
+from pyannote.core import Annotation
+from pyannote.core import Segment
+from pyannote.metrics.detection import DetectionErrorRate
+from pyannote.metrics.diarization import DiarizationErrorRate
+from pyannote.metrics.diarization import JaccardErrorRate
+
+import numpy.testing as npt
+
+
+@pytest.fixture
+def files():
+    reference1 = Annotation(uri="file1")
+    reference1[Segment(0, 10)] = "A"
+    reference1[Segment(12, 20)] = "B"
+    reference1[Segment(24, 27)] = "A"
+    reference1[Segment(30, 40)] = "C"
+
+    hypothesis1 = Annotation(uri="file1")
+    hypothesis1[Segment(2, 13)] = "a"
+    hypothesis1[Segment(13, 14)] = "d"
+    hypothesis1[Segment(14, 20)] = "b"
+    hypothesis1[Segment(22, 38)] = "c"
+    hypothesis1[Segment(38, 40)] = "d"
+
+    reference2 = Annotation(uri="file2")
+    reference2[Segment(0, 5)] = "A"
+    reference2[Segment(6, 10)] = "B"
+    reference2[Segment(12, 13)] = "B"
+    reference2[Segment(15, 20)] = "A"
+
+    hypothesis2 = Annotation(uri="file2")
+    hypothesis2[Segment(1, 6)] = "a"
+    hypothesis2[Segment(6, 7)] = "b"
+    hypothesis2[Segment(7, 10)] = "c"
+    hypothesis2[Segment(11, 19)] = "b"
+    hypothesis2[Segment(19, 20)] = "a"
+
+    return [(reference1, hypothesis1), (reference2, hypothesis2)]
+
+
+def evaluate_separately(make_metric, files):
+    metrics = []
+    for reference, hypothesis in files:
+        metric = make_metric()
+        metric(reference, hypothesis)
+        metrics.append(metric)
+    return metrics
+
+
+@pytest.mark.parametrize(
+    "make_metric",
+    [
+        lambda: DiarizationErrorRate(collar=0.5, skip_overlap=True),
+        lambda: DetectionErrorRate(collar=0.5),
+    ],
+)
+def test_sum_matches_single_metric(files, make_metric):
+    single = make_metric()
+    for reference, hypothesis in files:
+        single(reference, hypothesis)
+
+    per_file = evaluate_separately(make_metric, files)
+    # otherwise the test could not tell summing apart from keeping one file
+    assert abs(per_file[0]) != pytest.approx(abs(single))
+
+    for combined in (per_file[0] + per_file[1], sum(per_file)):
+        npt.assert_almost_equal(abs(combined), abs(single), decimal=7)
+        assert combined[:] == pytest.approx(single[:])
+        assert [uri for uri, _ in combined] == ["file1", "file2"]
+
+
+def test_sum_after_pickling(files):
+    # joblib and multiprocessing send each worker's metric back pickled
+    single = DiarizationErrorRate(collar=0.5)
+    for reference, hypothesis in files:
+        single(reference, hypothesis)
+
+    per_file = evaluate_separately(lambda: DiarizationErrorRate(collar=0.5), files)
+    per_file = [pickle.loads(pickle.dumps(metric)) for metric in per_file]
+
+    npt.assert_almost_equal(abs(sum(per_file)), abs(single), decimal=7)
+
+
+def test_clone_keeps_options_but_not_results(files):
+    reference, hypothesis = files[0]
+    metric = DiarizationErrorRate(collar=0.5, skip_overlap=True)
+    metric(reference, hypothesis)
+
+    clone = metric.clone()
+
+    assert clone is not metric
+    assert (clone.collar, clone.skip_overlap) == (0.5, True)
+    assert clone.results_ == []
+    assert all(value == 0.0 for value in clone.accumulated_.values())
+    assert len(metric.results_) == 1
+
+
+def test_add_refuses_different_options(files):
+    reference, hypothesis = files[0]
+    loose = DiarizationErrorRate(collar=0.5)
+    strict = DiarizationErrorRate(collar=0.0)
+    loose(reference, hypothesis)
+    strict(reference, hypothesis)
+
+    with pytest.raises(ValueError, match="collar"):
+        loose + strict
+
+
+def test_add_refuses_different_metrics(files):
+    reference, hypothesis = files[0]
+    der = DiarizationErrorRate()
+    jer = JaccardErrorRate()
+    der(reference, hypothesis)
+    jer(reference, hypothesis)
+
+    with pytest.raises(TypeError, match="Cannot add"):
+        der + jer
+
+
+def test_sum_does_not_modify_summands(files):
+    per_file = evaluate_separately(DiarizationErrorRate, files)
+    accumulated = [dict(metric.accumulated_) for metric in per_file]
+
+    total = sum(per_file)
+    total(*files[0])
+
+    assert [metric.accumulated_ for metric in per_file] == accumulated
+    assert [len(metric.results_) for metric in per_file] == [1, 1]


### PR DESCRIPTION
Picks up #67 by @nryant and addresses the review there.

Metrics can now be combined with `+` or `sum()`: each worker evaluates its own files, and the metrics are added afterwards. Nothing runs in parallel inside the library, so the import-time manager removed in #54 stays gone. `clone()` returns an empty metric with the same options, and adding metrics of different classes or options raises.

`clone()` copies attributes other than `results_` and `accumulated_` instead of using `get_params()`, since `LowLatencySpeakerSpotting` only sets `thresholds` when given. Docs get a "Parallel processing" section; 7 new tests include a pickle round trip.
